### PR TITLE
A 'ValueError' when checking for package resources will skip that resource

### DIFF
--- a/morphi/messages/manager.py
+++ b/morphi/messages/manager.py
@@ -256,7 +256,7 @@ def gettext_find(domain, localedir=None, languages=None, all=False,  # noqa: C90
                 else:
                     return mofile_lp
 
-        except NotImplementedError:
+        except (NotImplementedError, ValueError):
             pass
 
     return result

--- a/morphi/tests/test_messages.py
+++ b/morphi/tests/test_messages.py
@@ -176,12 +176,17 @@ class TestMessagesManagerFindMoFilename(object):
             yield gettext_find
 
     @pytest.fixture(scope='function')
-    def path_exists(self):
+    def path_exists_enclosure(self):
         with mock.patch(
                 'morphi.libs.packages.enclose_package_path_exists',
-                autospec=True, spec_set=True, return_value=lambda path: False
+                autospec=True, spec_set=True,
+                return_value=mock.Mock(side_effect=lambda path: False)
         ) as enclosure:
-            yield enclosure.return_value
+            yield enclosure
+
+    @pytest.fixture(scope='function')
+    def path_exists(self, path_exists_enclosure):
+        yield path_exists_enclosure.return_value
 
     @pytest.fixture(scope='function')
     def expected(self, path_exists):
@@ -232,6 +237,12 @@ class TestMessagesManagerFindMoFilename(object):
 
         # attempted_domain, attempted_dirname, languages, all, path_exists=path_exists
         assert expected == gettext_find.call_args_list
+
+    def test_invalid_package_resource_path_throws_no_error(self, path_exists_enclosure):
+        path_exists_enclosure.return_value.side_effect = ValueError
+
+        manager.find_mo_filename(domain='domain', localedir='localedir', languages=['es'],
+                                 package_name='package_name', extension='ext')
 
     def test_file_found(self, path_exists, gettext_find):
         def find_package_i18n_es_path_exists(domain, dirname, languages, all,


### PR DESCRIPTION
Fixes #5