### PR TITLE
Babel 2.8 and CI helpers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,4 @@
-version: 2
+version: 2.1
 
 jobs:
   build:

--- a/morphi/messages/frontend.py
+++ b/morphi/messages/frontend.py
@@ -62,6 +62,8 @@ class CompileJson(babel.messages.frontend.compile_catalog, object):
         if not po_files:
             raise DistutilsOptionError('no message catalogs found')
 
+        catalogs_and_errors = {}
+
         for idx, (locale, po_file) in enumerate(po_files):
             json_file = json_files[idx]
             with open(po_file, 'rb') as infile:
@@ -84,7 +86,8 @@ class CompileJson(babel.messages.frontend.compile_catalog, object):
                 self.log.info('catalog %s is marked as fuzzy, skipping', po_file)
                 continue
 
-            for message, errors in catalog.check():
+            catalogs_and_errors[catalog] = catalog_errors = list(catalog.check())
+            for message, errors in catalog_errors:
                 for error in errors:
                     self.log.error(
                         'error: %s:%d: %s', po_file, message.lineno, error
@@ -97,6 +100,8 @@ class CompileJson(babel.messages.frontend.compile_catalog, object):
 
             with open(json_file, 'w') as outfile:
                 self._write_json(outfile, catalog, use_fuzzy=self.use_fuzzy)
+
+        return catalogs_and_errors
 
     @staticmethod
     def _write_json(outfile, catalog, use_fuzzy=False):

--- a/morphi/messages/validation.py
+++ b/morphi/messages/validation.py
@@ -1,0 +1,53 @@
+import subprocess
+import sys
+
+
+def check_translations(
+    root_path,
+    package_name,
+    locales=frozenset(['es']),
+    ignored_strings=frozenset(),
+):
+    # extract messages through to catalogs
+    setup_py = str(root_path / 'setup.py')
+    subprocess.run(['python', setup_py, 'extract_messages'])
+    subprocess.run(['python', setup_py, 'update_catalog', '--no-fuzzy-matching'])
+    subprocess.run(['python', setup_py, 'compile_catalog'])
+    subprocess.run(['python', setup_py, 'compile_json'])
+
+    found_fuzzy = False
+    untranslated_strings = []
+
+    # check for fuzzy matches
+    for locale in locales:
+        po_path = (
+            root_path / package_name / 'i18n' / locale / 'LC_MESSAGES'
+            / '{}.po'.format(package_name)
+        )
+        with open(po_path, mode='rb') as fp:
+            contents = fp.read()
+            found_fuzzy = found_fuzzy or b'#, fuzzy' in contents
+
+            fp.seek(0)
+            from babel.messages.pofile import read_po
+            load_catalog = read_po(fp)
+            for message in load_catalog:
+                if message.id in ignored_strings:
+                    continue
+                if message.id and not message.string:
+                    untranslated_strings.append('{}: {}'.format(locale, message.id))
+
+    # note: the strings below are intentionally left untranslated
+    if found_fuzzy:
+        print('Detected fuzzy translations.')
+
+    if untranslated_strings:
+        print('Did not find translations for the following strings:')
+        for item in untranslated_strings:
+            print('    ', item)
+
+    if found_fuzzy or untranslated_strings:
+        print('Edit the PO file and compile the catalogs.')
+        sys.exit(1)
+
+    print('No detected translation issues.')

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,34,35,36,37},flake8
+envlist = py{36,37,38},flake8
 
 [testenv]
 usedevelop = false


### PR DESCRIPTION
- small update required to work with Babel 2.7+ (affects the compile-json command)
- add a helper method that checks PO files for missing translations